### PR TITLE
Fix Embedder snapshot OOM + show search time on the site

### DIFF
--- a/docs/plans/HANDOFF.md
+++ b/docs/plans/HANDOFF.md
@@ -1,0 +1,33 @@
+# HANDOFF — Performance + UX work
+
+**Updated:** 2026-06-25 17:14 PDT
+**Branch:** `claude/sweet-gauss-646781` (descends from `gradio`)
+**PRs:** [#12](https://github.com/ronboger/conformal-protein-retrieval/pull/12) merged to `gradio`; [#13](https://github.com/ronboger/conformal-protein-retrieval/pull/13) open (OOM fix + search timer)
+**Prod:** deployed and live — https://doudna-lab--cpr-gradio-ui.modal.run (Modal app `cpr-gradio`)
+
+## Current state (what's live + tested)
+All shipped to prod; 95 tests passing (`conda run -n conformal-s pytest tests/`):
+- **Cold start:** prebuilt FAISS sidecar indexes on the `cpr-data` volume (skip ~1 GB np.load + build); CPU memory snapshot on the Embedder (**now `memory=32768`** — it was OOM-killing on creation, exit 137, causing ~86s reloads every cold start).
+- **Embedding:** fp16 autocast on ProtTrans T5 (head stays fp32); GPU-resident embed (no per-seq GPU↔CPU round-trip); A10G; fan-out across containers for >600 seqs (genome-scale). All verified bit-identical (Syn3.0 59/149, cosine 1.0).
+- **Caching/payload:** process-level embedding LRU; collision-safe cache key; display cap (200/query to browser, download returns all); input cap 5000 (genome-scale → CLI).
+- **UI:** Search↔Stop toggle; uploaded FASTA shown in the box; **`⏱ Search completed in X.Xs`** above the summary.
+- **CLI:** `cpr embed/search --fast` (fp16 "fast mode").
+
+## Open next steps (priority order)
+1. **Merge PR #13** (the OOM fix + timer; already on prod, just not merged).
+2. **Run the 4×-gap diagnostic from a reliable connection** (the cluster's Modal/GitHub DNS is flaky — see gotchas):
+   `modal run scripts/modal_diagnose.py`
+   Prints the Modal A10G runtime stack + per-stage ms/seq. Mystery: identical embed code is ~35 ms/seq on a cluster A5000 but ~100 ms/seq on Modal A10G. Likely causes (Codex): dep-stack mismatch (loose torch/cuDNN vs cluster's pinned `torch 2.1+cu121+cudnn8`) or CPU starvation (no `cpu=` set → ~1–2 vCPUs). Act on the output:
+   - old/mismatched torch/cuDNN → pin the Embedder image to the cluster stack
+   - `cpu_count` 1–2 or high `tokenize`/`h2d` → add `cpu=4` to the Embedder `@app.cls`
+   - `t5` dominates and is high → genuinely GPU-bound → only a bigger GPU helps
+   If a fix lands, re-verify with `scripts/slurm_verify_fp16.sh` (Syn3.0 must stay 59/149).
+3. **Branch consolidation** (on hold by choice): `main` is an unrelated/stale history (last change 2026-02-04, 0 files unique to it). `gradio` is the real source of truth. To get one branch: force `main` = `gradio` + delete `gradio`/`claude/*`, OR repoint the GitHub default to `gradio`. Until done, `git clone` (default `main`) gets stale code without `--fast`.
+4. **Paid perf (only if needed):** warm GPU pool (kills the ~32s cold start) or A100 (faster compute).
+
+## Gotchas / context
+- **Cluster → Modal/GitHub DNS is intermittent.** `*.modal.run` web URLs, `modal run`, and `git push`/`gh` to github.com fail randomly *from the cluster login node*; the Modal control plane (`modal deploy`) and `gh` API mostly work. **Run `modal run` diagnostics + git ops from your Mac.**
+- **Every deploy invalidates the Embedder snapshot** (gradio_interface is in the GPU image), so the first search after any deploy is a one-time slow snapshot *creation* (~60–90s), then fast.
+- **Don't re-try:** GPU memory snapshot (`enable_gpu_snapshot`) segfaults on restore (exit 139) on this config; embedding batching is bit-identical but *slower* (padding waste) — both ruled out with evidence.
+- Verify scripts: `scripts/verify_fp16.py`, `verify_batch.py`, `verify_gpu_resident.py` (+ `slurm_verify_*.sh`); diagnostics: `modal_diagnose.py`, `modal_bench_*.py`.
+- Full changelog: the `## Development Log` section in `CLAUDE.md`.

--- a/modal_app.py
+++ b/modal_app.py
@@ -147,12 +147,15 @@ def _check_volume_data():
     gpu="A10G",  # ~4x faster than T4 for the per-sequence T5 forwards (Syn3.0 = 149);
                  # scales to zero, so ~cost-neutral per search (faster offsets higher rate).
     timeout=600,
+    # Snapshotting the ~11 GB fp32 ProtTrans model needs headroom or creation
+    # OOM-kills (exit 137) and falls back to a slow full reload on every cold start.
+    memory=32768,
     volumes={VOLUME_PATH: volume},
     secrets=[dataset_config_secret],
     enable_memory_snapshot=True,
     # NOTE: experimental GPU memory snapshot (enable_gpu_snapshot) segfaults on
-    # restore (exit 139) on this config and Modal falls back to a full reload that
-    # is SLOWER than a normal cold start -- removed. CPU snapshot below works.
+    # restore (exit 139) on this config; removed. The CPU snapshot needs the
+    # memory above to create successfully.
 )
 class Embedder:
     """GPU-accelerated protein embedding using ProtTrans + Protein-Vec.

--- a/protein_conformal/backend/gradio_interface.py
+++ b/protein_conformal/backend/gradio_interface.py
@@ -1604,6 +1604,7 @@ MDKKYSIGLDIGTNSVGWAVITDEYKVPSKKFKVLGNTDRHSIKKNLIGALLFDSGETAEATRLKRTARRRYTRRKNRIC
                             visible=False,
                         )
 
+                        search_timer_md = gr.Markdown("")
                         results_summary = gr.Code(language="json", label="Search Summary", interactive=False)
 
                         with gr.Row():
@@ -1827,6 +1828,7 @@ MIRDFNNQEVTLDDLEQNNNKTDKNKPKVQFLMRFSLVFSNISTHIFLFVLIVIASLFFGLRYTYYNYKVDLITNAHKIK
         def on_submit(mode, fasta, upload, risk_t, risk_v, max_k, use_pv, custom_emb,
                       lookup, metadata, custom_lookup, custom_meta, m_type,
                       min_prob, hide_unc, c_alpha, session):
+            _t0 = time.perf_counter()
             if mode == "Enzyme Classification (CLEAN)":
                 # CLEAN enzyme classification pipeline
                 summary_json, df, session = process_clean_input(
@@ -1840,6 +1842,7 @@ MIRDFNNQEVTLDDLEQNNNKTDKNKPKVQFLMRFSLVFSNISTHIFLFVLIVIASLFFGLRYTYYNYKVDLITNAHKIK
                     unique_queries = []
                     choices = ["All queries"]
                 return (
+                    f"**⏱ Search completed in {time.perf_counter() - _t0:.1f}s**",
                     summary_json,
                     df,
                     gr.Dropdown(choices=choices, value=unique_queries[0] if unique_queries else "All queries"),
@@ -1868,6 +1871,7 @@ MIRDFNNQEVTLDDLEQNNNKTDKNKPKVQFLMRFSLVFSNISTHIFLFVLIVIASLFFGLRYTYYNYKVDLITNAHKIK
                 plot_label = unique_queries[0] if unique_queries else None
                 fig = _build_prob_plot(session, query_label=plot_label)
                 return (
+                    f"**⏱ Search completed in {time.perf_counter() - _t0:.1f}s**",
                     summary_json,
                     df,
                     gr.Dropdown(choices=choices, value=unique_queries[0] if unique_queries else "All queries"),
@@ -1898,7 +1902,7 @@ MIRDFNNQEVTLDDLEQNNNKTDKNKPKVQFLMRFSLVFSNISTHIFLFVLIVIASLFFGLRYTYYNYKVDLITNAHKIK
                 clean_alpha,
                 session_state,
             ],
-            outputs=[results_summary, results_table, query_filter, sequence_detail, prob_plot, session_state]
+            outputs=[search_timer_md, results_summary, results_table, query_filter, sequence_detail, prob_plot, session_state]
         )
         # Revert to Search when the search finishes normally.
         search_event.then(fn=_idle, inputs=None, outputs=[submit_btn, stop_btn])

--- a/scripts/modal_diagnose.py
+++ b/scripts/modal_diagnose.py
@@ -1,0 +1,110 @@
+"""
+Diagnose the Modal-A10G-vs-cluster-A5000 4x embedding gap (Codex leads).
+
+Prints the runtime stack (torch/CUDA/cuDNN versions, vCPU count, SDPA backends)
+and a per-stage breakdown (tokenize / H2D / T5 forward / Protein-Vec head) so we
+can tell whether the gap is the stack, CPU starvation, or transfers.
+
+    modal run scripts/modal_diagnose.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import modal
+from modal_app import gpu_image, volume, VOLUME_PATH, PVM_DIR, HF_CACHE
+
+app = modal.App("cpr-diagnose", image=gpu_image)
+
+
+@app.function(gpu="A10G", volumes={VOLUME_PATH: volume}, timeout=600)
+def diagnose():
+    import re
+    import time
+    import torch
+    import numpy as np
+
+    sys.path.insert(0, PVM_DIR)
+    from transformers import T5EncoderModel, T5Tokenizer
+    import transformers
+    from model_protein_moe import trans_basic_block, trans_basic_block_Config
+    from utils_search import embed_vec
+
+    info = {
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "cuda": torch.version.cuda,
+        "cudnn": torch.backends.cudnn.version(),
+        "gpu": torch.cuda.get_device_name(0),
+        "os.cpu_count": os.cpu_count(),
+        "torch.get_num_threads": torch.get_num_threads(),
+        "flash_sdp": torch.backends.cuda.flash_sdp_enabled(),
+        "mem_efficient_sdp": torch.backends.cuda.mem_efficient_sdp_enabled(),
+    }
+
+    device = torch.device("cuda:0")
+    tok = T5Tokenizer.from_pretrained("Rostlab/prot_t5_xl_uniref50", do_lower_case=False, cache_dir=HF_CACHE)
+    model = T5EncoderModel.from_pretrained("Rostlab/prot_t5_xl_uniref50", cache_dir=HF_CACHE).to(device).eval()
+    config = trans_basic_block_Config.from_json(f"{PVM_DIR}/protein_vec_params.json")
+    model_deep = trans_basic_block.load_from_checkpoint(
+        f"{PVM_DIR}/protein_vec.ckpt", config=config, map_location=device
+    ).to(device).eval()
+    keys = np.array(["TM", "PFAM", "GENE3D", "ENZYME", "MFO", "BPO", "CCO"])
+    masks = torch.logical_not(torch.tensor([keys[k] in keys for k in range(len(keys))], dtype=torch.bool))[None, :]
+
+    seqs, cur = [], []
+    for line in open(f"{VOLUME_PATH}/data/gene_unknown/unknown_aa_seqs.fasta"):
+        line = line.strip()
+        if line.startswith(">"):
+            if cur:
+                seqs.append("".join(cur)); cur = []
+        elif line:
+            cur.append(line)
+    if cur:
+        seqs.append("".join(cur))
+    seqs = seqs[:20]
+
+    def one(s, acc):
+        t0 = time.perf_counter()
+        prepped = re.sub(r"[UZOB]", "X", " ".join(s[:3000]))
+        ids = tok.batch_encode_plus([prepped], add_special_tokens=True, padding=True)
+        acc["tokenize"] += time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        input_ids = torch.tensor(ids["input_ids"]).to(device)
+        attn = torch.tensor(ids["attention_mask"]).to(device)
+        torch.cuda.synchronize(); acc["h2d"] += time.perf_counter() - t0
+
+        torch.cuda.synchronize(); t0 = time.perf_counter()
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+            hidden = model(input_ids=input_ids, attention_mask=attn).last_hidden_state
+        torch.cuda.synchronize(); acc["t5"] += time.perf_counter() - t0
+
+        sl = int(attn[0].sum())
+        pt = hidden[0, : sl - 1].float().unsqueeze(0)
+        torch.cuda.synchronize(); t0 = time.perf_counter()
+        embed_vec(pt, model_deep, masks, device)
+        torch.cuda.synchronize(); acc["head"] += time.perf_counter() - t0
+
+    warm = {"tokenize": 0, "h2d": 0, "t5": 0, "head": 0}
+    for s in seqs[:3]:
+        one(s, warm)
+    acc = {"tokenize": 0, "h2d": 0, "t5": 0, "head": 0}
+    for s in seqs:
+        one(s, acc)
+    n = len(seqs)
+    timings = {k: round(v / n * 1000, 1) for k, v in acc.items()}
+    timings["total_ms_per_seq"] = round(sum(acc.values()) / n * 1000, 1)
+    return info, timings
+
+
+@app.local_entrypoint()
+def main():
+    info, timings = diagnose.remote()
+    print("\n=== MODAL A10G RUNTIME STACK ===")
+    for k, v in info.items():
+        print(f"  {k}: {v}")
+    print("\n=== PER-STAGE TIMING (ms/seq, 20 Syn3.0) ===")
+    for k, v in timings.items():
+        print(f"  {k}: {v}")


### PR DESCRIPTION
Follow-up to #12, already deployed to prod.

## Fixes
- **Embedder snapshot OOM** — the CPU memory-snapshot creation was OOM-killed (exit 137) snapshotting the ~11 GB ProtTrans model with no memory limit, so every cold start fell back to a slow full reload (~86s). Reserve `memory=32768` so the snapshot creates once and restores fast.
- **Visible search timer** — `⏱ Search completed in X.Xs` above the Search Summary, timed across the whole `on_submit` (Protein + CLEAN modes).
- Adds `scripts/modal_diagnose.py` to isolate the Modal-vs-cluster embed gap (runtime stack + per-stage timing).

## Verification
95 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
